### PR TITLE
Add ability to set custom parameter encoding #28

### DIFF
--- a/Sources/RestBird/Alamofire/Alamofire+ArrayEncoding.swift
+++ b/Sources/RestBird/Alamofire/Alamofire+ArrayEncoding.swift
@@ -1,0 +1,35 @@
+//
+//  Alamofire+ArrayEncoding.swift
+//  Monday
+//
+//  Created by Valter Mak on 4/28/19.
+//
+
+import Foundation
+import Alamofire
+
+public struct ArrayEncoding<T: Encodable>: ParameterEncoding {
+    
+    private let array: T
+    
+    public init(array: T) {
+        self.array = array
+    }
+    
+    public func encode(_ urlRequest: URLRequestConvertible, with parameters: Parameters?) throws -> URLRequest {
+        var urlRequest = try urlRequest.asURLRequest()
+        do {
+            let encoder = JSONEncoder()
+            let data = try encoder.encode(array)
+            if urlRequest.value(forHTTPHeaderField: "Content-Type") == nil {
+                urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            }
+            urlRequest.httpBody = data
+            
+        } catch {
+            throw AFError.parameterEncodingFailed(reason: .jsonEncodingFailed(error: error))
+        }
+        
+        return urlRequest
+    }
+}

--- a/Sources/RestBird/Alamofire/Alamofire+ArrayEncoding.swift
+++ b/Sources/RestBird/Alamofire/Alamofire+ArrayEncoding.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Alamofire
 
-public struct ArrayEncoding<T: Encodable>: ParameterEncoding {
+public struct ArrayEncoding<T: Encodable>: Alamofire.ParameterEncoding {
     
     private let array: T
     

--- a/Sources/RestBird/Alamofire/Request+Alamofire.swift
+++ b/Sources/RestBird/Alamofire/Request+Alamofire.swift
@@ -16,6 +16,12 @@ extension Request {
             return URLEncoding.default
         case .json:
             return JSONEncoding.default
+        case .custom(let encoding):
+            guard let encoding = encoding as? Alamofire.ParameterEncoding else {
+                return URLEncoding.default
+            }
+            
+            return encoding
         }
     }
 

--- a/Sources/RestBird/Request/ParameterEncoding.swift
+++ b/Sources/RestBird/Request/ParameterEncoding.swift
@@ -10,4 +10,5 @@ import Foundation
 public enum ParameterEncoding {
     case url
     case json
+    case custom(Any)
 }


### PR DESCRIPTION
Usage:

```
struct UpdateGroceryItemCheckStatus: DataRequest {
        typealias ResponseType = EmptyResponse
        typealias RequestType = [GroceryItemCheckStatus]
        let method: HTTPMethod = .put
        let suffix: String? = "\(API.Path.groceryItems)"
        let parameters: [GroceryItemCheckStatus]?
        
        var parameterEncoding: ParameterEncoding {
            return .custom(ArrayEncoding<[GroceryItemCheckStatus]>(array: self.parameters ?? []))
        }
        
        init(parameters: [GroceryItemCheckStatus]) {
            self.parameters = parameters
        }
    }
```